### PR TITLE
Update, install ca-certs, and upgrade apt pkgs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ COPY . .
 RUN make build
 
 FROM ubuntu:22.04 as runtime
+RUN apt update && apt install ca-certificates && apt upgrade
 COPY --from=build /go/src/admiral/out/ /bin/
 ENTRYPOINT ["/bin/admiral"]


### PR DESCRIPTION
## Description of the change

> Update, install ca-certs, and upgrade pkgs in Dockerfile

## Changes

* Dockerfile

## Impact

N/A
