### PR TITLE
Print the node description to the log

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -277,6 +277,7 @@ func (c *Controller) processItem(newEvent Event) error {
 	}
 
 	kbEvent.NodeDescription = fmt.Sprintf("%s \n %s", objectMetadata.ClusterName, c.podsOnNodeToString(objectMetadata))
+	logrus.Printf("KbEvent.NodeDescription: %s", kbEvent.NodeDescription)
 	c.eventHandler.Handle(kbEvent)
 	return nil
 }


### PR DESCRIPTION
## Description of the change

> Log the `nodeDescription` from the event to the console for visibility

## Changes

* Adds a log statement for derived nodeDescription property

## Impact

N/A
