### PR TITLE
Add cluster name as config parameter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	Handler   Handler  `json:"handler"`
 	Resource  Resource `json:"resource"`
 	Namespace string   `json:"namespace,omitempty"`
+	Cluster   string   `json:"cluster,omitempty"`
 }
 
 type Webhook struct {

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -3,27 +3,24 @@ package event
 import "fmt"
 
 type Event struct {
-	Namespace       string
-	Kind            string
-	Component       string
-	Host            string
-	Reason          string
-	Status          string
-	Name            string
-	NodeDescription string
+	Namespace string
+	Kind      string
+	Component string
+	Host      string
+	Reason    string
+	Status    string
+	Name      string
+	Cluster   string
 }
 
 // Message returns event message
 // These correlate to the informers defined in controller.go
 func (e *Event) Message() string {
-	msg := fmt.Sprintf("%s/%s: `%s`",
+	msg := fmt.Sprintf("%s %s/%s: `%s`",
+		e.Cluster,
 		e.Namespace,
 		e.Name,
 		e.Kind,
 	)
-
-	if e.NodeDescription != "" {
-		msg = fmt.Sprintf("%s \n %s", msg, e.NodeDescription)
-	}
 	return msg
 }


### PR DESCRIPTION
## Description of the change

> Adds an optional parameter to the config, `ClusterName`, allowing an operator to pass a `ClusterName` to the message.

## Changes

* Expands the config and message

## Impact

* N/A
