### PR TITLE
Capture and display affected pods on NodeNotReady

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -11,6 +11,7 @@ type Event struct {
 	Status    string
 	Name      string
 	Cluster   string
+	Extra     string
 }
 
 // Message returns event message
@@ -22,5 +23,10 @@ func (e *Event) Message() string {
 		e.Name,
 		e.Kind,
 	)
+
+	if e.Extra != "" {
+		msg = fmt.Sprintf("%s \n %s", msg, e.Extra)
+	}
+
 	return msg
 }


### PR DESCRIPTION
## Description of the change

> Trims the node name, then queries API server for pods on the crashed node, then attempts passing them along to the message.

## Changes

* Added functions for querying API server for pods on a crashing node
* Modified message

## Impact

* N/A
