### PR TITLE
Get all of the pods in any namespace on a node

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -291,7 +291,7 @@ func (c *Controller) processItem(newEvent Event) error {
 func (c *Controller) getPodsOnNode(m meta_v1.ObjectMeta) (s string) {
 	trimmedNodeName := trimNodeName(m.Name)
 	logrus.Printf("Trimmed Node Name: %s", trimmedNodeName)
-	pods, err := c.clientset.CoreV1().Pods(m.Namespace).List(context.Background(), meta_v1.ListOptions{FieldSelector: fmt.Sprintf("spec.nodeName=%s", trimmedNodeName)})
+	pods, err := c.clientset.CoreV1().Pods("").List(context.Background(), meta_v1.ListOptions{FieldSelector: fmt.Sprintf("spec.nodeName=%s", trimmedNodeName)})
 	if err != nil {
 		logrus.Fatalf("Failed matching pods to a node: %s", err)
 	}


### PR DESCRIPTION
## Description of the change

> Switches from namespacing the selection of pods on a node to looking in all of the namespaces for a pod on a node

## Changes

* Queries for pods using all namespaces instead of the namespace in the metadata queried from the event

## Impact

N/A
