### PR TITLE
Refactor event controller into its own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,18 @@ Presently, the application depends on a single configuration file:
 `${HOME}/.admiral.yaml`, which looks something like this:
 
 ```yaml
-webhook:
-    enabled: true
-    url: https://my.webhook.url
+cluster: my-cluster
+namespace: "" # Use all namespaces
+events:
+    handler:
+        webhook:
+            url: https://my.webhook.url
+logstream:
+    logstore:
+        loki:
+            url: https://loki.logging.svc.cluster.local:3100 # A svc named loki in the logging namespace
+    apps: # The label "app" on a pod
+        - name: my-app-deployment
 ```
 
 Based on the config, the application instantiates a handler. For now, the only

--- a/config/config.go
+++ b/config/config.go
@@ -16,29 +16,28 @@ type Handler struct {
 	Webhook Webhook `json:"webhook"`
 }
 
-type Resource struct {
-	Deployment            bool `json:"deployment"`
-	ReplicationController bool `json:"rc"`
-	ReplicaSet            bool `json:"rs"`
-	DaemonSet             bool `json:"ds"`
-	Services              bool `json:"svc"`
-	Pod                   bool `json:"po"`
-	Job                   bool `json:"job"`
-	Node                  bool `json:"node"`
-	ClusterRole           bool `json:"clusterrole"`
-	ServiceAccount        bool `json:"sa"`
-	PersistentVolume      bool `json:"pv"`
-	Namespace             bool `json:"ns"`
-	Secret                bool `json:"secret"`
-	ConfigMap             bool `json:"configmap"`
-	Ingress               bool `json:"ing"`
+type Config struct {
+	Events    Events    `json:"events"`
+	Logstream Logstream `json:"logstream"`
+	Namespace string    `json:"namespace,omitempty"`
+	Cluster   string    `json:"cluster,omitempty"`
 }
 
-type Config struct {
-	Handler   Handler  `json:"handler"`
-	Resource  Resource `json:"resource"`
-	Namespace string   `json:"namespace,omitempty"`
-	Cluster   string   `json:"cluster,omitempty"`
+type Logstream struct {
+	Logstore Logstore `json:"logstore"`
+	Apps     []string `json:"apps"`
+}
+
+type Logstore struct {
+	Loki Loki `json:"loki"`
+}
+
+type Loki struct {
+	Url string `json:"url"`
+}
+
+type Events struct {
+	Handler Handler `json:"handler"`
 }
 
 type Webhook struct {

--- a/pkg/controller/events.go
+++ b/pkg/controller/events.go
@@ -1,0 +1,74 @@
+package controller
+
+import (
+	"fmt"
+
+	"github.com/phil-inc/admiral/config"
+	"github.com/phil-inc/admiral/pkg/event"
+	"github.com/phil-inc/admiral/pkg/handlers"
+	api_v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type EventController struct {
+	informerFactory informers.SharedInformerFactory
+	eventInformer   coreinformers.EventInformer
+	handler         handlers.Handler
+	config          *config.Config
+}
+
+// Instantiates a controller for watching and handling events
+func NewEventController(informerFactory informers.SharedInformerFactory) *EventController {
+	eventInformer := informerFactory.Core().V1().Events()
+
+	c := &EventController{
+		informerFactory: informerFactory,
+		eventInformer:   eventInformer,
+	}
+
+	eventInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    c.onEventAdd,
+			UpdateFunc: c.onEventUpdate,
+			DeleteFunc: c.onEventDelete,
+		},
+	)
+
+	return c
+}
+
+func (c *EventController) Run(stopCh chan struct{}) error {
+	c.informerFactory.Start(stopCh)
+	if !cache.WaitForCacheSync(stopCh, c.eventInformer.Informer().HasSynced) {
+		return fmt.Errorf("failed to sync")
+	}
+	return nil
+}
+
+// when an event object is created
+func (c *EventController) onEventAdd(obj interface{}) {
+	e := obj.(*api_v1.Event)
+
+	if serverStartTime.After(e.ObjectMeta.CreationTimestamp.Time) {
+		return
+	}
+
+	switch e.Reason {
+	case "NodeNotReady", "Unhealthy":
+		c.handler.Handle(event.Event{
+			Namespace: e.ObjectMeta.Namespace,
+			Kind:      e.Reason,
+			Cluster:   c.config.Cluster,
+			Name:      e.ObjectMeta.Name,
+			Extra:     e.Message,
+		})
+	}
+}
+
+// when an event object is updated
+func (c *EventController) onEventUpdate(old, new interface{}) {}
+
+// when an event object is deleted
+func (c *EventController) onEventDelete(obj interface{}) {}

--- a/pkg/handlers/webhook/webhook.go
+++ b/pkg/handlers/webhook/webhook.go
@@ -22,7 +22,7 @@ type WebhookMessage struct {
 
 // Init creates the webhook configuration
 func (w *Webhook) Init(c *config.Config) error {
-	url := c.Handler.Webhook.Url
+	url := c.Events.Handler.Webhook.Url
 
 	w.url = url
 

--- a/pkg/logstores/logstore.go
+++ b/pkg/logstores/logstore.go
@@ -1,0 +1,13 @@
+package logstores
+
+import "github.com/phil-inc/admiral/config"
+
+type Logstore interface {
+	Init(c *config.Config) error
+}
+
+type Default struct{}
+
+func (d *Default) Init(c *config.Config) error {
+	return nil
+}

--- a/pkg/logstores/loki/loki.go
+++ b/pkg/logstores/loki/loki.go
@@ -1,0 +1,28 @@
+package loki
+
+import (
+	"fmt"
+
+	"github.com/phil-inc/admiral/config"
+)
+
+type Loki struct {
+	url string
+}
+
+// Init creates the loki configuration
+func (l *Loki) Init(c *config.Config) error {
+	url := c.Logstream.Logstore.Loki.Url
+
+	l.url = url
+
+	return checkMissingVars(l)
+}
+
+func checkMissingVars(l *Loki) error {
+	if l.url == "" {
+		return fmt.Errorf("Loki URL not set")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description of the change

> Refactors the `event` controller into its own file with an `informer` instantiated from a shared factory. This way, when we instantiate the `podInformer` for streaming logs, we can use the same cache (and decouple the controllers). 

## Changes

* Updates the config so it can handle log streaming
* Adds a separate controller for events

## Impact

* Old controller was left untouched, so the new event controller can run side-by-side until we are satisfied with its implementation.
