### PR TITLE
Fix nil pointer in events controller

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -62,7 +62,7 @@ func Start(conf *config.Config, eventHandler handlers.Handler, logStore logstore
 
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, time.Second*30)
 
-	eventCtrl := NewEventController(informerFactory)
+	eventCtrl := NewEventController(informerFactory, eventHandler, conf)
 	eventStop := make(chan struct{})
 	defer close(eventStop)
 	err := eventCtrl.Run(eventStop)


### PR DESCRIPTION
## Description of the change

> Fixes an issue where the `events` controller was being instantiated without a pointer to the config. When the controller attempted referencing the config to format the webhook message, nil pointer error would crash the app.

## Changes

* Fix `events` controller struct

## Impact

* N/A
