### PR TITLE
Add logstore for streaming logs into Loki

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,7 +19,7 @@ import (
 var serverStartTime time.Time
 
 // Start creates the informerFactory and initializes controllers
-func Start(conf *config.Config, eventHandler handlers.Handler, logStore logstores.Logstore) {
+func Start(conf *config.Config, eventHandler handlers.Handler, logstore logstores.Logstore) {
 	var kubeClient kubernetes.Interface
 
 	if _, err := rest.InClusterConfig(); err != nil {
@@ -38,7 +38,7 @@ func Start(conf *config.Config, eventHandler handlers.Handler, logStore logstore
 		logrus.Fatal(err)
 	}
 
-	podCtrl := NewPodController(informerFactory, kubeClient, conf)
+	podCtrl := NewPodController(informerFactory, kubeClient, conf, logstore)
 	podStop := make(chan struct{})
 	defer close(podStop)
 	err = podCtrl.Run(podStop)

--- a/pkg/logstores/logstore.go
+++ b/pkg/logstores/logstore.go
@@ -1,13 +1,20 @@
 package logstores
 
-import "github.com/phil-inc/admiral/config"
+import (
+	"github.com/phil-inc/admiral/config"
+)
 
 type Logstore interface {
 	Init(c *config.Config) error
+	Stream(log string) error
 }
 
 type Default struct{}
 
 func (d *Default) Init(c *config.Config) error {
+	return nil
+}
+
+func (d *Default) Stream(log string) error {
 	return nil
 }

--- a/pkg/logstores/loki/loki.go
+++ b/pkg/logstores/loki/loki.go
@@ -2,12 +2,24 @@ package loki
 
 import (
 	"fmt"
+	"bytes"
+	"net/http"
+	"encoding/json"
 
 	"github.com/phil-inc/admiral/config"
 )
 
 type Loki struct {
 	url string
+}
+
+type LokiDTO struct {
+	Streams []Streams `json:"streams"`
+}
+
+type Streams struct {
+	Stream map[string]string `json:"stream"`
+	Values [][]string `json:"values"`
 }
 
 // Init creates the loki configuration
@@ -17,6 +29,42 @@ func (l *Loki) Init(c *config.Config) error {
 	l.url = url
 
 	return checkMissingVars(l)
+}
+
+// Stream sends the logs to Loki
+func (l *Loki) Stream(log string) error {
+	msg := &LokiDTO{
+		Streams: []Streams{
+			{
+				Stream: map[string]string{
+					"label1": "label2",
+				},
+				Values: [][]string{
+					[]string{log},
+				},
+			},
+		},
+	}
+	
+
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", l.url, bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	client := &http.Client{}
+	_, err = client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func checkMissingVars(l *Loki) error {


### PR DESCRIPTION
## Description of the change

> Adds a `logstore` for streaming logs into `Loki` instead of printing them to STDOUT

## Changes

* Fleshed out `Loki.Stream()`

## Impact

* If `Loki.Stream()` fails it could raise an exception and crash the service
