### PR TITLE
Change log for streaming from fatal to error

### DIFF
--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -117,7 +117,7 @@ func (c *PodController) streamLogsFromPod(pod *api_v1.Pod) {
 				SinceSeconds: &sinceSeconds,
 			}).Stream(context.Background())
 			if err != nil {
-				logrus.Fatal(err)
+				logrus.Error(err)
 			}
 			defer stream.Close()
 


### PR DESCRIPTION
## Description of the change

> Changes `logrus.Fatal()` to `logrus.Error()` when searching for a log stream. When we deployed Admiral as pods were updating, it would attempt to stream logs from the terminating pod and then crash.

## Changes

* Changes `logrus.Fatal()` to `logrus.Error()` in `pkg/controllers/pods.go`

## Impact

* Hopefully it should reduce crashing
