### PR TITLE
Fix concurrency for streaming logs from every container in a pod

### DIFF
--- a/pkg/controller/events.go
+++ b/pkg/controller/events.go
@@ -61,7 +61,7 @@ func (c *EventController) onEventAdd(obj interface{}) {
 
 	if serverStartTime.Before(e.ObjectMeta.CreationTimestamp.Time) {
 		switch e.Reason {
-		case "NodeNotReady", "Unhealthy":
+		case "NodeNotReady":
 			c.handler.Handle(c.newSendableEvent(e))
 		}
 	}


### PR DESCRIPTION
## Description of the change

> Referencing the value returned from looping over the range of containers in a pod was causing uncaught race condition in goroutines inside of the loop. For example, if a pod had 2 containers (capi, datadog-agent), the goroutine inside of the loop would reference the container in the last iteration.

## Changes

* Fix concurrency when streaming logs from multiple containers in a pod.

## Impact

* N/A
