### PR TITLE
Switch log labels to the pod labels

### DIFF
--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -137,7 +137,7 @@ func (c *PodController) streamLogsFromPod(pod *api_v1.Pod) {
 
 			for logs.Scan() {
 				// do something with each log line
-				err := c.logstore.Stream(logs.Text(), pod.ObjectMeta.Name, con.Name)
+				err := c.logstore.Stream(logs.Text(), pod.ObjectMeta.Labels)
 				if err != nil {
 					logrus.Fatalf("Failed streaming log to logstore: %s", err)
 				}
@@ -166,8 +166,6 @@ func (c *PodController) podIsInConfig(pod *api_v1.Pod) bool {
 }
 
 func getLogstreamName(pod *api_v1.Pod, container api_v1.Container) string {
-
 	name := fmt.Sprintf("%s.%s.%s", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, container.Name)
-
 	return name
 }

--- a/pkg/logstores/logstore.go
+++ b/pkg/logstores/logstore.go
@@ -6,7 +6,7 @@ import (
 
 type Logstore interface {
 	Init(c *config.Config) error
-	Stream(log string, pod string, container string) error
+	Stream(log string, logMetadata map[string]string) error
 }
 
 type Default struct{}
@@ -15,6 +15,6 @@ func (d *Default) Init(c *config.Config) error {
 	return nil
 }
 
-func (d *Default) Stream(log string, pod string, container string) error {
+func (d *Default) Stream(log string, logMetadata map[string]string) error {
 	return nil
 }

--- a/pkg/logstores/loki/loki.go
+++ b/pkg/logstores/loki/loki.go
@@ -33,14 +33,11 @@ func (l *Loki) Init(c *config.Config) error {
 }
 
 // Stream sends the logs to Loki
-func (l *Loki) Stream(log string, pod string, container string) error {
+func (l *Loki) Stream(log string, logMetadata map[string]string) error {
 	msg := &LokiDTO{
 		Streams: []Streams{
 			{
-				Stream: map[string]string{
-					"pod": pod,
-					"container": container,
-				},
+				Stream: logMetadata,
 				Values: [][]string{
 					[]string{fmt.Sprintf("%d", time.Now().UnixNano()), log},
 				},


### PR DESCRIPTION
## Description of the change

> Switches the labels in Loki to match the labels on the pod

## Changes

* Instead of pod name and container name, the controller passes the pod labels (map[string]string) to Loki

## Impact

* N/A
