### PR TITLE
Remove sinceseconds and add logging at end of scanner

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -30,6 +30,8 @@ func Start(conf *config.Config, eventHandler handlers.Handler, logstore logstore
 
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, time.Second*30)
 
+	serverStartTime = time.Now()
+
 	eventCtrl := NewEventController(informerFactory, eventHandler, conf, kubeClient)
 	eventStop := make(chan struct{})
 	defer close(eventStop)

--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -112,13 +112,10 @@ func (c *PodController) streamLogsFromPod(pod *api_v1.Pod) {
 			c.logstream[name] = make(chan struct{})
 			c.logstreamMu.Unlock()
 
-			sinceSeconds := int64(1)
-
 			stream, err := c.clientset.CoreV1().Pods(pod.ObjectMeta.Namespace).GetLogs(pod.ObjectMeta.Name, &api_v1.PodLogOptions{
 				Container: con.Name,
 				Follow: true,
 				Timestamps: true,
-				SinceSeconds: &sinceSeconds,
 			}).Stream(context.Background())
 			if err != nil {
 				logrus.Error(err)
@@ -142,6 +139,7 @@ func (c *PodController) streamLogsFromPod(pod *api_v1.Pod) {
 					logrus.Fatalf("Failed streaming log to logstore: %s", err)
 				}
 			}
+			logrus.Printf("Scanner for %s closed", name)
 		}()
 	}
 }


### PR DESCRIPTION
## Description of the change

> Removes `SinceSeconds` from log streamer and prints logs when the scanner completes

## Changes

* Removes `SinceSeconds` parameter on log streamer so we capture all logs since beginning of container's life
* Adds log message when scanner completes

## Impact

* N/A
