### PR TITLE
Add unhealthy event handler back

### DIFF
--- a/pkg/controllers/events/events.go
+++ b/pkg/controllers/events/events.go
@@ -75,7 +75,7 @@ func (c *EventController) onEventAdd(obj interface{}) {
 
 	if serverStartTime.Before(e.ObjectMeta.CreationTimestamp.Time) {
 		switch e.Reason {
-		case "NodeNotReady":
+		case "NodeNotReady", "Unhealthy":
 			c.handler.Handle(c.newSendableEvent(e))
 		}
 	}


### PR DESCRIPTION
## Description of the change

> Turn on messages for `unhealthy` events. We're noticing a gap in Loki where some of the log streams close. Our hypothesis is the stream closes when the pods periodically become `unhealthy`. We believe that is due to a transient network issue. This change is to hopefully correlate that behavior with the gaps in logging.

## Changes

* Just adding `Unhealthy` to the case of event messaging

## Impact

* N/A
