### PR TITLE
Change deferred closure of logstream to closing the channel

### DIFF
--- a/pkg/controllers/logs/logs.go
+++ b/pkg/controllers/logs/logs.go
@@ -123,8 +123,7 @@ func (c *LogController) streamLogsFromPod(pod *api_v1.Pod) {
 				logrus.Error(err)
 			}
 			logrus.Printf("Opened logstream: %s", name)
-			defer stream.Close()
-
+			defer close(c.logstream[name])
 			// concurrently wait for the receiver to close, then close the stream
 			go func() {
 				<-c.logstream[name]


### PR DESCRIPTION
## Description of the change

> Seeing periodic issue where Admiral immediately drops the logs from a new pod. Looks like it may be caused by the `defer` keyword closing the stream at the end of the scope, but not closing the channel storing the pod's status. This could happen if Admiral sees a pod is running, but no logs are available, so the loop parsing the log stream immediately ends and closes the scope.

* [Asana issue](https://app.asana.com/0/406568776885776/1201659889919031/f)

## Changes

* In the log controller, change `defer stream.Close()` to `defer close(c.logstream[name])`. 

This should trigger the event handler signaling that Admiral is not receiving logs from a specific pod and should gracefully remove that pod from the map of watched pods. Then, Admiral can properly re-add the pod.

## Impact

* N/A
