### PR TITLE
Build sha-tagged image on release

### DIFF
--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -8,12 +8,14 @@ on:
 jobs:
   push-latest-image:
     name: Build & Push Latest Image
+    env:
+      SHORT_SHA: ${GITHUB_SHA::8}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Build Latest
-        run: docker build . -t philinc/admiral:latest
+        run: docker build . -t philinc/admiral:${SHORT_SHA}
       - name: Login
         run: docker login -u ${{ secrets.docker_username }} -p ${{ secrets.docker_password }}
       - name: Push Latest
-        run: docker push philinc/admiral:latest
+        run: docker push philinc/admiral:${SHORT_SHA}


### PR DESCRIPTION
## Description of the change

> Changes build for `release` branch to use a shortened commit sha as the tag

* [Asana issue](https://app.asana.com/0/406568776885776/1201660350879400/f)

## Changes

* Change github workflow tag on release branch docker image

## Impact

* N/A
