### PR TITLE
Remove deferred closure of logstream on error

### DIFF
--- a/pkg/controllers/logs/logs.go
+++ b/pkg/controllers/logs/logs.go
@@ -122,7 +122,6 @@ func (c *LogController) streamLogsFromPod(pod *api_v1.Pod) {
 
 			if err != nil {
 				logrus.Errorf("Failed opening logstream %s: %s", name, err)
-				close(c.logstream[name])
 			} else {
 				logrus.Printf("Opened logstream: %s", name)
 				defer close(c.logstream[name])


### PR DESCRIPTION
## Description of the change

> On logstream error, admiral was closing the channel, but because of the error it never actually opened

* [Asana issue](https://app.asana.com/0/406568776885776/1201659889919031/f)

## Changes

* Removes a `Close()` that was targeting a channel that never gets created

## Impact

* N/A
