### PR TITLE
Remove closure when log scanner fails

### DIFF
--- a/pkg/controllers/logs/logs.go
+++ b/pkg/controllers/logs/logs.go
@@ -146,8 +146,8 @@ func (c *LogController) streamLogsFromPod(pod *api_v1.Pod) {
 
 				if logs.Err() != nil {
 					logrus.Errorf("Scanner failed %s: %s", name, logs.Err())
-					close(c.logstream[name])
 				}
+
 				logrus.Printf("Scanner for %s closed", name)
 			}
 		}()


### PR DESCRIPTION
## Description of the change

> When log scanner failed, the error handler was closing the channel, which was also being closed by the `defer` keyword, causing Admiral to panic with `panic: close of closed channel`

* [Asana issue](https://app.asana.com/0/406568776885776/1201659889919031/f)

## Changes

* Removes a `close()` line that was closing a closed channel and panicking

## Impact

* N/A
