### PR TITLE
Switch dev build/push to master branch

### DIFF
--- a/.github/workflows/on_push_or_pull_request.yaml
+++ b/.github/workflows/on_push_or_pull_request.yaml
@@ -4,11 +4,9 @@ on:
   push:
     branches-ignore:
       - master
-      - release
   pull_request:
     branches:
       - master
-      - release
 
 jobs:
   lint-repo:

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -3,7 +3,7 @@ name: Releases
 on:
   push:
     branches:
-      - release
+      - master
 
 jobs:
   push-latest-image:


### PR DESCRIPTION
## Description of the change

> Modifies GitHub Action so dev build/push happen on `master` instead of `release`

## Changes

* Does dev build/push on `master`
* Removes `release` from ignored branches in "build on push"

## Impact

* N/A
