### PR TITLE
Switch from fatal to error log when logstream fails

### DIFF
--- a/pkg/controllers/logs/logs.go
+++ b/pkg/controllers/logs/logs.go
@@ -150,7 +150,7 @@ func (c *LogController) streamLogsFromPod(pod *api_v1.Pod) {
 
 					err := c.logstore.Stream(logs.Text(), formatLogMetadata(logMetaData))
 					if err != nil {
-						logrus.Fatalf("Failed streaming log to logstore: %s", err)
+						logrus.Errorf("Failed streaming log to logstore: %s", err)
 					}
 				}
 


### PR DESCRIPTION
## Description of the change

> When the logstream fails (example: loki is updating), Admiral crashes. This commit handles the error more gracefully

## Changes

* Replaced `logrus.Fatalf()` with `logrus.Errorf()` when Admiral fails to POST to the logstore.

## Impact

* N/A
