### PR TITLE
Check if logstream channel is closed before closing on delete handler

### DIFF
--- a/pkg/controllers/logs/logs.go
+++ b/pkg/controllers/logs/logs.go
@@ -168,7 +168,9 @@ func (c *LogController) stopLogStreamFromPod(pod *api_v1.Pod) {
 	logrus.Printf("Stopped streaming logs from %s", pod.ObjectMeta.Name)
 	for _, container := range pod.Spec.Containers {
 		name := getLogstreamName(pod, container)
-		close(c.logstream[name])
+		if stream, ok := c.logstream[name]; ok {
+			close(stream)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description of the change

> When a pod changes from `Running` to `Terminating`, code closes the channel. When a pod is out-right deleted, it also closes the channel. This panics if it tries closing an already-closed channel. This PR adds a safety check onDelete() to see if the channel is already closed.

## Changes

* Adds safety check to `stopLogStreamFromPod()`

## Impact

* N/A
