### PR TITLE
Add safety check to deferred closure

### DIFF
--- a/pkg/controllers/logs/logs.go
+++ b/pkg/controllers/logs/logs.go
@@ -124,8 +124,11 @@ func (c *LogController) streamLogsFromPod(pod *api_v1.Pod) {
 				logrus.Errorf("Failed opening logstream %s: %s", name, err)
 			} else {
 				logrus.Printf("Opened logstream: %s", name)
-				defer close(c.logstream[name])
-
+				defer func() {
+					if stream, ok := c.logstream[name]; ok {
+						close(stream)
+					}
+				}()
 				// concurrently wait for the receiver to close, then close the stream
 				go func() {
 					<-c.logstream[name]


### PR DESCRIPTION
## Description of the change

> Occasionally, the channel `c.logstream[name]` is closed, then the scope of `streamLogsFromPod()` closes, triggering a race condition between `delete(c.logstream[name])` and `defer close(c.logstream[name])`. This PR adds a safety check to the deferred closure so it verifies the value has not been deleted before closing.

## Changes

* Wraps `defer close(c.logstream[name])` in a function checking whether or not `c.logstream[name]` still exists

## Impact

* N/A
