### PR TITLE
Fix kubeclient contract

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -29,7 +29,7 @@ func Run(conf *config.Config, operation string) error {
 	if notInCluster != nil {
 		kubeClient, err = utils.GetClientOutOfCluster()
 	} else {
-		kubeClient, err = utils.GetClientOutOfCluster()
+		kubeClient, err = utils.GetClient()
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description of the change

> Fix kubeconfig client contract

## Changes

* Kubeconfig client contract was looking for the incluster config out of cluster and failing

## Impact

* N/A
