### PR TITLE
Revert pushing logs through to stdout

### DIFF
--- a/pkg/controllers/logs/logstream.go
+++ b/pkg/controllers/logs/logstream.go
@@ -63,7 +63,7 @@ func (l *logstream) Start(clientset kubernetes.Interface) {
 			}
 			logMetaData["pod"] = l.pod
 			logMetaData["namespace"] = l.namespace
-			logrus.Printf("%s: %s", l.pod, logs.Text())
+
 			err := l.logstore.Stream(logs.Text(), formatLogMetadata(logMetaData))
 			if err != nil {
 				logrus.Errorf("Failed streaming log to logstore: %s", err)


### PR DESCRIPTION
## Description of the change

> May have been a red herring as the dropped pod caught up eventually. Reverting this change since it will pollute the logs.

## Changes

* Reverts the "route all logs to stdout & loki" debugger

## Impact

* N/A
