### PR TITLE
ignore_logs labels if container name matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ logstream:
             url: https://loki.logging.svc.cluster.local:3100 # A svc named loki in the logging namespace
     apps: # The label "app" on a pod
         - my-app-deployment
+ignorecontainers: [datadog-agent] # an array of container names to ignore
 ```
 
 Based on the config, the application instantiates a handler. For now, the only

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	Performance      Performance `json:"performance"`
 	Namespace        string      `json:"namespace,omitempty"`
 	Cluster          string      `json:"cluster,omitempty"`
-	IgnoreContainers []string    `json:"ignore_containers,omitempty"`
+	IgnoreContainers []string    `json:"ignorecontainers"`
 }
 
 type Logstream struct {

--- a/pkg/controllers/logs/logs.go
+++ b/pkg/controllers/logs/logs.go
@@ -97,7 +97,9 @@ func (c *LogController) onPodDelete(obj interface{}) {
 
 func (c *LogController) newPod(pod *api_v1.Pod) {
 	for _, container := range pod.Spec.Containers {
-		if !ignoreContainer(pod, container.Name, c.config) {
+
+		if !ignoreContainer(pod, container.Name, c.config.IgnoreContainers) {
+
 			name := getLogstreamName(pod, container)
 			stream := NewLogstream(pod.Namespace, pod.Name, container.Name, pod.Labels, c.logstore)
 			_, exists := c.logstreams[name]
@@ -161,15 +163,18 @@ func getLogstreamName(pod *api_v1.Pod, container api_v1.Container) string {
 	return name
 }
 
-func ignoreContainer(pod *api_v1.Pod, container string, config *config.Config) bool {
-	labels := strings.Split(pod.ObjectMeta.Labels["ignore_logs"], ",")
-	for _, label := range labels {
-		if label == container {
+func ignoreContainer(pod *api_v1.Pod, containerName string, ignoreContainers []string) bool {
+	for _, c := range ignoreContainers {
+
+		if c == containerName {
 			return true
 		}
 	}
-	for _, c := range config.IgnoreContainers {
-		if c == container {
+
+	labels := strings.Split(pod.ObjectMeta.Labels["ignore_logs"], ",")
+	for _, label := range labels {
+
+		if label == containerName {
 			return true
 		}
 	}


### PR DESCRIPTION
## Description of the change

Ignore logs from containers that match metadata labels from each application

* [Asana link](https://app.asana.com/0/1202526686884392/1202541365535896/f)

## Changes
Removing any containers that match against the ObjectMeta.Labels field. Currently the only value will be datadog-agent, which is the name all apps are using for the DD sidecar.

* What changes are included in this PR?
Modify the newPod() function to check container names before creating new logstreams
 
## Impact

* Any infrastructure related impact
Will require restarting pods before this would take effect. Will need to modify the metadata in phil-cicd as well as this change.

* Any security related impact
No
