### PR TITLE
Add restart for logstream & local config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,8 @@ type Logstream struct {
 }
 
 type Logstore struct {
-	Loki Loki `json:"loki"`
+	Loki  Loki `json:"loki"`
+	Local bool `josn:"local"`
 }
 
 type Performance struct {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/phil-inc/admiral/pkg/handlers"
 	"github.com/phil-inc/admiral/pkg/handlers/webhook"
 	"github.com/phil-inc/admiral/pkg/logstores"
+	"github.com/phil-inc/admiral/pkg/logstores/local"
 	"github.com/phil-inc/admiral/pkg/logstores/loki"
 	"github.com/phil-inc/admiral/pkg/target"
 	"github.com/phil-inc/admiral/pkg/target/web"
@@ -85,6 +86,8 @@ func ParseLogHandler(conf *config.Config) logstores.Logstore {
 	switch {
 	case len(conf.Logstream.Logstore.Loki.Url) > 0:
 		logHandler = new(loki.Loki)
+	case conf.Logstream.Logstore.Local:
+		logHandler = new(local.Local)
 	default:
 		logHandler = new(logstores.Default)
 	}

--- a/pkg/controllers/logs/logs.go
+++ b/pkg/controllers/logs/logs.go
@@ -101,7 +101,7 @@ func (c *LogController) newPod(pod *api_v1.Pod) {
 		if !ignoreContainer(pod, container.Name, c.config.IgnoreContainers) {
 
 			name := getLogstreamName(pod, container)
-			stream := NewLogstream(pod.Namespace, pod.Name, container.Name, pod.Labels, c.logstore)
+			stream := NewLogstream(pod.Namespace, pod.Name, container.Name, pod.Labels, c.logstore, c.clientset)
 			_, exists := c.logstreams[name]
 
 			if exists {
@@ -114,7 +114,7 @@ func (c *LogController) newPod(pod *api_v1.Pod) {
 				c.logstreams[name] = stream
 			}
 
-			stream.Start(c.clientset)
+			stream.Start(nil)
 		}
 	}
 }

--- a/pkg/logstores/local/local.go
+++ b/pkg/logstores/local/local.go
@@ -1,0 +1,18 @@
+package local
+
+import (
+	"github.com/phil-inc/admiral/config"
+	"github.com/sirupsen/logrus"
+)
+
+type Local struct{}
+
+func (l *Local) Init(c *config.Config) error {
+	return nil
+}
+
+// Stream sends the logs to STDOUT
+func (l *Local) Stream(log string, logMetadata map[string]string) error {
+	logrus.Printf(log)
+	return nil
+}


### PR DESCRIPTION
## Description of the change

> Adds a restart to the logstream. We've noticed an issue where after a period of time, Kubernetes will post blank logs to the bufio scanner, resulting in "" getting pushed to the logstore. This PR aims to handle that case by restarting the logstream with a "SinceTime" value of when that blank log was first found, so the new logstream should pick up there instead of grabbing the whole history of logs. 

## Changes

* Adds `l.Restart()` to `logstream.go`
* Adds a config for local log testing (just print to stdout)
