### PR TITLE
Set bash as the default shell

### DIFF
--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -9,6 +9,9 @@ jobs:
   build_push:
     name: Build and Push
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - name: generate-tag
       uses: phil-inc/public-actions/.github/actions/generate-tag@master


### PR DESCRIPTION
# Summary

The workflow runs are getting errors saying a shell is not set. We can specify it on every `run:` step in the composite actions, but it's simpler to set it here as the job default (if it works).

# Changes

- .github/workflows/on_pr.yaml - set the default shell for the job to be bash

# Anything Else
