### PR TITLE
Get the tag from env instead of output

### DIFF
--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -9,18 +9,15 @@ jobs:
   build_push:
     name: Build and Push
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     steps:
     - name: generate-tag
       uses: phil-inc/public-actions/.github/actions/generate-tag@master
     - name: build-push
-      if: ${{ steps.generate-tag.outputs.tag }} != ''
+      if: ${{ env.tag }} != ''
       uses: phil-inc/public-actions/.github/actions/build-push@master
       with:
         name: admiral
-        tag: ${{ steps.generate-tag.outputs.tag }}
+        tag: ${{ env.tag }}
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         region: "us-east-1"


### PR DESCRIPTION
# Summary

The `generate-tag` composite action stores the generated tag in the shared context `env` instead of making an output variable because making it an output required an extra step. I forgot this when I was updating this workflow for admiral, so this PR makes use of the `env` context instead of looking for a non-existent output variable.

# Changes

- .github/workflows/on_pr.yaml - uses the `env` context for retrieving the tag instead of expecting an output from the `generate-tag` action

# Anything Else
