### PR TITLE
Assume a role when archiving the repository

### DIFF
--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -15,6 +15,7 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        assume-role: ${{ secrets.assume_role }}
     - name: generate-tag
       uses: phil-inc/public-actions/.github/actions/generate-tag@master
     - name: build-push

--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -15,7 +15,7 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        assume-role: ${{ secrets.assume_role }}
+        assume-role: ${{ secrets.ARCHIVE_CODE_REPOSITORIES_ROLE }}
     - name: generate-tag
       uses: phil-inc/public-actions/.github/actions/generate-tag@master
     - name: build-push


### PR DESCRIPTION
# Summary

Assumes a role when archiving the repository instead of just relying on the user's permissions

# Changes

- .github/workflows/on_pr.yaml - referenced the `assume_role` secret to pass a role to the composite action

# Anything Else
