### PR TITLE
Move repo archival to the end of the workflow

### DIFF
--- a/.github/workflows/on_pr.yaml
+++ b/.github/workflows/on_pr.yaml
@@ -10,12 +10,6 @@ jobs:
     name: Build and Push
     runs-on: ubuntu-latest
     steps:
-    - name: archive-repo
-      uses: phil-inc/public-actions/.github/actions/archive-repo@master
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        assume-role: ${{ secrets.ARCHIVE_CODE_REPOSITORIES_ROLE }}
     - name: generate-tag
       uses: phil-inc/public-actions/.github/actions/generate-tag@master
     - name: build-push
@@ -32,3 +26,9 @@ jobs:
         google-chat-webhook: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
         docker-username: ${{ secrets.docker_username }}
         docker-password: ${{ secrets.docker_password }}
+    - name: archive-repo
+      uses: phil-inc/public-actions/.github/actions/archive-repo@master
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        assume-role: ${{ secrets.ARCHIVE_CODE_REPOSITORIES_ROLE }}


### PR DESCRIPTION
# Summary

Repo archival should be done at the end so as not to hold up builds.

# Changes

- .github/workflows/on_pr.yaml - moved the `archive-repo` step to the end of the job

# Anything Else
